### PR TITLE
ZENITH-39631: Fix the DELETE Method tests to assert with 403

### DIFF
--- a/src/be/configuration/config_parser.py
+++ b/src/be/configuration/config_parser.py
@@ -37,3 +37,24 @@ def get_token():
     post_response = requests.post(get_config_value("auth_host") + "/oauth2/token", data=payload, headers=headers)
     logger.info("Running tests on " + str(os.getenv("ENV")) + " environment.")
     return "Bearer " + post_response.json()['access_token']
+
+
+def assert_by_auth_type(response, config):
+    """
+    Assert the response status code based on the 'xapi' setting in config.
+    Args:
+        response: The HTTP response object with a status_code attribute.
+        config: Dict-like object with 'xapi' key (expects 'on' or 'off').
+    Raises:
+        AssertionError if the response status code does not match expected.
+    """
+    xapi_setting = config.get("xapi")
+    if xapi_setting == "on":
+        expected_status = 403
+    else:
+        expected_status = 404
+    assert response.status_code == expected_status, (
+        f"Expected status {expected_status} for xapi='{xapi_setting}', "
+        f"but got {response.status_code}"
+    )
+

--- a/src/be/configuration/dev-config.cfg
+++ b/src/be/configuration/dev-config.cfg
@@ -19,5 +19,5 @@ auth_host = https://authdev.np.digitalzenith.io
 remit = GBR
 
 ###### Authentication Type [xapi = on - through x-api-key, xapi = off - through auth bearer token] #######
-xapi = off
+xapi = on
 api_key = 92a86fdd-c804-493b-afe2-61a7ea59d115

--- a/src/be/configuration/stage-config.cfg
+++ b/src/be/configuration/stage-config.cfg
@@ -19,5 +19,5 @@ auth_host = https://auth.stage.digitalzenith.io
 remit = GBR
 
 ###### Authentication Type [xapi = on - through x-api-key, xapi = off - through auth bearer token] #######
-xapi = on
+xapi = off
 api_key = 99b5fe03-99cf-4eaa-9346-361b679ac0db

--- a/src/be/configuration/stage-config.cfg
+++ b/src/be/configuration/stage-config.cfg
@@ -19,5 +19,5 @@ auth_host = https://auth.stage.digitalzenith.io
 remit = GBR
 
 ###### Authentication Type [xapi = on - through x-api-key, xapi = off - through auth bearer token] #######
-xapi = off
+xapi = on
 api_key = 99b5fe03-99cf-4eaa-9346-361b679ac0db

--- a/src/be/tests/activities/candidate_activities/test_delete_candidate_activities.py
+++ b/src/be/tests/activities/candidate_activities/test_delete_candidate_activities.py
@@ -19,10 +19,9 @@ def test_delete_candidate_activities_without_dependencies():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, candidate_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_activity_request(base_url, endpoint, candidate_id, act_id, headers)
-    assert get_response.status_code == 404
-
+    assert get_response.status_code == 200
 
 def test_delete_candidate_activity_unauthorized():
     post_response = create_activity_request(base_url, endpoint, candidate_id, create_candidate_activity_full_payload(),
@@ -39,8 +38,7 @@ def test_delete_candidate_activity_nonexistent_id():
     assert post_response.status_code == 200
     # using candidate id instead of candidate activity id
     delete_response = delete_activity_request(base_url, endpoint, candidate_id, candidate_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_candidate_activity_already_deleted():
@@ -49,10 +47,7 @@ def test_delete_candidate_activity_already_deleted():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, candidate_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
-    delete_response = delete_activity_request(base_url, endpoint, candidate_id, act_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_candidate_activity_original():
@@ -61,6 +56,4 @@ def test_delete_candidate_activity_original():
     assert create_response.status_code == 200
     act_id = create_response.json()['id']
     delete_response = delete_original_activity_request(base_url, act_id, delete_headers)
-    assert delete_response.status_code == 204
-    get_response = get_original_activity_request(base_url, act_id, headers)
-    assert get_response.status_code == 404
+    assert delete_response.status_code == 403

--- a/src/be/tests/activities/candidate_activities/test_get_candidate_activities.py
+++ b/src/be/tests/activities/candidate_activities/test_get_candidate_activities.py
@@ -1,9 +1,11 @@
+from src.be.configuration.config_parser import assert_by_auth_type
 from src.be.definitions.candidates_definitions import get_candidate_id
 from src.be.utilities.candidates_utilities.request_payloads.create_candidate_activity_payload import *
 from src.be.utilities.error_schema import error_schema
 from src.be.utilities.useful_functions import validate_response_schema_and_fields
 from src.be.utilities.candidates_utilities.json_schemas.get_candidate_activity_schema import \
     get_candidate_activity_schema
+
 
 base_url = get_config_value("base_url")
 endpoint = "candidates/"
@@ -38,8 +40,9 @@ def test_get_candidate_activity_by_nonexistent_id():
 
 def test_get_candidate_activity_by_id_misspelled_endpoint():
     response = get_activity_request(base_url, "candidate/", candidate_id, activity_id, headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_candidate_activity_original():

--- a/src/be/tests/activities/candidate_activities/test_post_candidate_activities.py
+++ b/src/be/tests/activities/candidate_activities/test_post_candidate_activities.py
@@ -5,6 +5,7 @@ from src.be.utilities.candidates_utilities.request_payloads.create_candidate_act
 from src.be.utilities.error_schema import error_schema
 from src.be.utilities.candidates_utilities.json_schemas.post_candidate_activity_schema import \
     post_candidate_activity_schema
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "candidates/"
@@ -55,7 +56,9 @@ def test_create_candidate_activity_unauthorized():
 def test_create_candidate_activity_misspelled_endpoint():
     payload = create_candidate_activity_required_payload()
     activity_response = create_activity_request(base_url, "candidate/", candidate_id, payload, headers)
-    assert activity_response.status_code == 404
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(activity_response, config)
 
 
 def test_create_candidate_activity_empty_payload():

--- a/src/be/tests/activities/client_activities/test_delete_client_activities.py
+++ b/src/be/tests/activities/client_activities/test_delete_client_activities.py
@@ -26,9 +26,9 @@ def test_delete_client_activities_successful_request():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, client_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_activity_request(base_url, endpoint, client_id, act_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
 
 
 def test_delete_client_activity_unauthorized():
@@ -45,8 +45,7 @@ def test_delete_client_activity_nonexistent_id():
                                             headers)
     assert post_response.status_code == 200
     delete_response = delete_activity_request(base_url, endpoint, client_id, client_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_client_activity_already_deleted():
@@ -55,10 +54,7 @@ def test_delete_client_activity_already_deleted():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, client_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
-    delete_response = delete_activity_request(base_url, endpoint, client_id, act_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_client_activity_original():
@@ -67,6 +63,6 @@ def test_delete_client_activity_original():
     assert create_response.status_code == 200
     act_id = create_response.json()['id']
     delete_response = delete_original_activity_request(base_url, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_original_activity_request(base_url, act_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200

--- a/src/be/tests/activities/client_activities/test_get_client_activities.py
+++ b/src/be/tests/activities/client_activities/test_get_client_activities.py
@@ -6,7 +6,7 @@ from src.be.utilities.clients_utilities.json_schemas.get_client_activity_schema 
 from src.be.utilities.clients_utilities.request_payloads.create_client_activity_payload import \
     create_client_activity_required_payload, create_client_activity_full_payload, \
     create_client_activity_original_full_payload
-from src.be.utilities.error_schema import error_schema
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "clients/"
@@ -41,8 +41,9 @@ def test_get_client_activity_by_nonexistent_id():
 
 def test_get_client_activity_by_id_misspelled_endpoint():
     response = get_activity_request(base_url, "client/", client_id, activity_id, headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_client_activity_original():

--- a/src/be/tests/activities/client_activities/test_post_client_activities.py
+++ b/src/be/tests/activities/client_activities/test_post_client_activities.py
@@ -13,6 +13,7 @@ from src.be.utilities.error_schema import error_schema
 from src.be.utilities.useful_functions import validate_response_with_expected_json, \
     missing_required_field_payload, random_string, standard_headers
 from src.be.utilities.useful_functions import validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "clients/"
@@ -64,8 +65,9 @@ def test_create_client_activity_unauthorized():
 def test_create_client_activity_wrong_endpoint_name():
     payload = create_client_activity_required_payload()
     activity_response = create_activity_request(base_url, "client/", client_id, payload, headers)
-    assert activity_response.status_code == 404
-    validate_response_schema_and_fields(activity_response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(activity_response, config)
 
 
 def test_create_client_activity_empty_payload():

--- a/src/be/tests/activities/job_activities/test_delete_job_activities.py
+++ b/src/be/tests/activities/job_activities/test_delete_job_activities.py
@@ -20,9 +20,9 @@ def test_delete_job_activities_successful_request():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, job_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_activity_request(base_url, endpoint, job_id, act_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
 
 
 def test_delete_job_activity_unauthorized():
@@ -32,8 +32,7 @@ def test_delete_job_activity_unauthorized():
 
 def test_delete_job_activity_nonexistent_id():
     delete_response = delete_activity_request(base_url, endpoint, job_id, job_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_activity_already_deleted():
@@ -42,10 +41,7 @@ def test_delete_job_activity_already_deleted():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, job_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
-    delete_response = delete_activity_request(base_url, endpoint, job_id, act_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_activity_original():
@@ -54,6 +50,6 @@ def test_delete_job_activity_original():
     assert create_response.status_code == 200
     act_id = create_response.json()['id']
     delete_response = delete_original_activity_request(base_url, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_original_activity_request(base_url, act_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200

--- a/src/be/tests/activities/job_activities/test_get_job_activities.py
+++ b/src/be/tests/activities/job_activities/test_get_job_activities.py
@@ -10,6 +10,7 @@ from src.be.utilities.job_utilities.request_payloads.create_job_activity_payload
 from src.be.utilities.job_utilities.request_payloads.create_job_payload import create_job_required_fields_payload
 from src.be.utilities.useful_functions import validate_response_with_expected_json, get_random_uuid, standard_headers, \
      validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "jobs/"
@@ -45,8 +46,9 @@ def test_get_job_activity_by_nonexistent_id():
 
 def test_get_job_activity_by_id_misspelled_endpoint():
     response = get_activity_request(base_url, "job/", job_id, activity_id, headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_job_activity_original():

--- a/src/be/tests/activities/job_activities/test_post_job_activities.py
+++ b/src/be/tests/activities/job_activities/test_post_job_activities.py
@@ -11,6 +11,7 @@ from src.be.utilities.job_utilities.request_payloads.create_job_activity_payload
 from src.be.utilities.job_utilities.request_payloads.create_job_payload import create_job_required_fields_payload
 from src.be.utilities.useful_functions import validate_response_with_expected_json, \
     random_string, missing_required_field_payload, standard_headers, validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "jobs/"
@@ -70,8 +71,9 @@ def test_create_job_activity_unauthorized():
 def test_create_job_activity_misspelled_endpoint():
     payload = create_job_activity_required_fields_payload()
     activity_response = create_activity_request(base_url, "job/", job_id, payload, headers)
-    assert activity_response.status_code == 404
-    validate_response_schema_and_fields(activity_response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(activity_response, config)
 
 
 def test_create_job_activity_empty_payload():

--- a/src/be/tests/activities/organisation_activities/test_delete_organisation_activities.py
+++ b/src/be/tests/activities/organisation_activities/test_delete_organisation_activities.py
@@ -22,9 +22,9 @@ def test_delete_organisation_activities_without_dependencies():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, org_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_activity_request(base_url, endpoint, org_id, act_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
 
 
 def test_delete_organisation_activity_unauthorized():
@@ -34,8 +34,7 @@ def test_delete_organisation_activity_unauthorized():
 
 def test_delete_organisation_activity_nonexistent_id():
     delete_response = delete_activity_request(base_url, endpoint, org_id, org_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_organisation_activity_already_deleted():
@@ -45,10 +44,7 @@ def test_delete_organisation_activity_already_deleted():
     assert post_response.status_code == 200
     act_id = post_response.json()['id']
     delete_response = delete_activity_request(base_url, endpoint, org_id, act_id, delete_headers)
-    assert delete_response.status_code == 204
-    delete_response = delete_activity_request(base_url, endpoint, org_id, act_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_organisation_activity_original():
@@ -57,6 +53,6 @@ def test_delete_organisation_activity_original():
     assert create_response.status_code == 200
     act_id = create_response.json()['id']
     delete_response = delete_original_activity_request(base_url, act_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_original_activity_request(base_url, act_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200

--- a/src/be/tests/activities/organisation_activities/test_get_organisation_activities.py
+++ b/src/be/tests/activities/organisation_activities/test_get_organisation_activities.py
@@ -16,6 +16,7 @@ from src.be.utilities.organisations_utilities.request_payloads.create_organisati
     create_organisation_required_payload
 from src.be.utilities.useful_functions import validate_response_schema_and_fields, \
     validate_response_with_expected_json, get_random_uuid, standard_headers
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "organisations/"
@@ -57,13 +58,9 @@ def test_get_organisation_activity_by_nonexistent_id():
 
 def test_get_organisation_activity_by_id_misspelled_endpoint():
     response = get_activity_request(base_url, "organisation/", org_id, activity_id, headers)
-    assert response.status_code == 404
-    schema = error_schema
-    validate(response.json(), schema=schema)
-    response_fields = set(response.json().keys())
-    schema_fields = set(schema.get("properties", {}).keys())
-    assert response_fields == schema_fields, f"Response fields do not match schema. Expected: {schema_fields}, \
-    Got: {response_fields}"
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_organisation_activity_original():

--- a/src/be/tests/activities/organisation_activities/test_post_organisation_activities.py
+++ b/src/be/tests/activities/organisation_activities/test_post_organisation_activities.py
@@ -16,6 +16,7 @@ from src.be.utilities.organisations_utilities.request_payloads.create_organisati
     create_organisation_required_payload
 from src.be.utilities.useful_functions import validate_response_with_expected_json, \
     random_string, missing_required_field_payload, standard_headers, validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "organisations/"
@@ -75,8 +76,9 @@ def test_create_organisation_activity_unauthorized():
 def test_create_organisation_activity_misspelled_endpoint():
     payload = create_organisation_activity_required_payload()
     activity_response = create_activity_request(base_url, "organisation/", org_id, payload, headers)
-    assert activity_response.status_code == 404
-    validate_response_schema_and_fields(activity_response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(activity_response, config)
 
 
 def test_create_organisation_activity_empty_payload():

--- a/src/be/tests/candidates/test_delete_candidates.py
+++ b/src/be/tests/candidates/test_delete_candidates.py
@@ -16,25 +16,25 @@ delete_headers = delete_headers()
 def test_delete_candidate_without_dependencies():
     candidate_id = get_candidate_id()
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
     get_response = get_candidates_by_id(base_url, endpoint, candidate_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     get_core_response = get_candidates_by_id_from_core_api(candidate_id)
-    assert get_core_response.status_code == 404
+    assert get_core_response.status_code == 200
 
 
 def test_delete_candidate_with_activities_checking_dependencies():
     candidate_id = get_candidate_id()
     add_activity_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_contacts_checking_dependencies():
     candidate_id = get_candidate_id()
     add_contact_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
     candidate_contacts = get_contacts_for_candidate(candidate_id)
     assert candidate_contacts.json()['metadata']['total'] == 1
 
@@ -43,7 +43,7 @@ def test_delete_candidate_with_alerts_checking_dependencies():
     candidate_id = get_candidate_id()
     add_alert_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
     candidate_alerts = get_alerts_for_candidate(candidate_id)
     assert candidate_alerts.json()['metadata']['total'] == 1
 
@@ -52,89 +52,89 @@ def test_delete_candidate_with_suitability_industries_checking_dependencies():
     candidate_id = get_candidate_id()
     add_suitability_industry_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_suitability_language_checking_dependencies():
     candidate_id = get_candidate_id()
     add_suitability_language_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_qualification_checking_dependencies():
     candidate_id = get_candidate_id()
     add_qualification_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_reviews_checking_dependencies():
     candidate_id = get_candidate_id()
     add_review_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_interview_notes_checking_dependencies():
     candidate_id = get_candidate_id()
     add_interview_notes_to_candidate(candidate_id)
     response = delete_candidates_check_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_interview_notes_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_interview_notes_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_reviews_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_review_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_qualification_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_qualification_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_candidate_with_suitability_language_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_suitability_language_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
     get_response = get_candidates_by_id(base_url, endpoint, candidate_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     get_core_response = get_candidates_by_id_from_core_api(candidate_id)
-    assert get_core_response.status_code == 404
+    assert get_core_response.status_code == 200
 
 
 def test_delete_candidate_with_activities_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_activity_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
     get_response = get_candidates_by_id(base_url, endpoint, candidate_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     get_core_response = get_candidates_by_id_from_core_api(candidate_id)
-    assert get_core_response.status_code == 404
+    assert get_core_response.status_code == 200
 
 
 def test_delete_candidate_with_contacts_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_contact_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
     get_response = get_candidates_by_id(base_url, endpoint, candidate_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     get_core_response = get_candidates_by_id_from_core_api(candidate_id)
-    assert get_core_response.status_code == 404
+    assert get_core_response.status_code == 200
     candidate_contacts = get_contacts_for_candidate(candidate_id)
     assert candidate_contacts.json()['metadata']['total'] == 1
 
@@ -143,11 +143,11 @@ def test_delete_candidate_with_alerts_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_alert_to_candidate(candidate_id)
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
     get_response = get_candidates_by_id(base_url, endpoint, candidate_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     get_core_response = get_candidates_by_id_from_core_api(candidate_id)
-    assert get_core_response.status_code == 404
+    assert get_core_response.status_code == 200
     candidate_alerts = get_alerts_for_candidate(candidate_id)
     assert candidate_alerts.json()['metadata']['total'] == 1
 
@@ -164,12 +164,12 @@ def test_delete_candidate_without_auth():
 
 def test_delete_candidate_wrong_candidate_id():
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, get_random_uuid(), delete_headers)
-    assert response.status_code == 404
+    assert response.status_code == 403
 
 
 def test_delete_candidate_already_deleted():
     candidate_id = get_candidate_id()
     response = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
     response2 = delete_candidates_ignore_dependencies_request(base_url, endpoint, candidate_id, delete_headers)
-    assert response2.status_code == 404
+    assert response2.status_code == 403

--- a/src/be/tests/candidates/test_get_candidates_by_id.py
+++ b/src/be/tests/candidates/test_get_candidates_by_id.py
@@ -5,6 +5,7 @@ from src.be.utilities.error_schema import error_schema
 from src.be.utilities.candidates_utilities.json_schemas.get_candidate_by_id_schema import get_candidate_by_id_schema
 from src.be.definitions.candidates_definitions import get_candidate_id, get_candidates_by_id
 from src.be.utilities.useful_functions import get_random_uuid, standard_headers, validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "candidates/"
@@ -35,8 +36,9 @@ def test_get_candidate_by_id_json_schema():
 
 def test_get_candidate_by_id_misspelled_endpoint():
     response = get_candidates_by_id(base_url, "wrong" + endpoint, candidate_id, headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_candidate_by_id_wrong_format():

--- a/src/be/tests/clients/test_delete_client.py
+++ b/src/be/tests/clients/test_delete_client.py
@@ -17,11 +17,11 @@ def test_delete_client_without_dependencies():
     assert create_response.status_code == 200
     client_id = create_response.json()['id']
     delete_response = delete_client_request(base_url, endpoint, client_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_client_request(base_url, endpoint, client_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     core_api_response = get_client_by_id_from_core_api(client_id)
-    assert core_api_response.status_code == 404
+    assert core_api_response.status_code == 200
 
 
 def test_delete_client_with_activities_checking_dependencies():
@@ -30,7 +30,7 @@ def test_delete_client_with_activities_checking_dependencies():
     client_id = create_response.json()['id']
     add_activity_to_client(client_id)
     response = delete_clients_check_dependencies_request(base_url, endpoint, client_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_client_with_alerts_checking_dependencies():
@@ -39,7 +39,7 @@ def test_delete_client_with_alerts_checking_dependencies():
     client_id = create_response.json()['id']
     add_alert_to_client(client_id)
     response = delete_clients_check_dependencies_request(base_url, endpoint, client_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_client_with_reviews_checking_dependencies():
@@ -48,7 +48,7 @@ def test_delete_client_with_reviews_checking_dependencies():
     client_id = create_response.json()['id']
     add_review_to_client(client_id)
     response = delete_clients_check_dependencies_request(base_url, endpoint, client_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_client_with_activities_ignore_dependencies():
@@ -57,7 +57,7 @@ def test_delete_client_with_activities_ignore_dependencies():
     client_id = create_response.json()['id']
     add_activity_to_client(client_id)
     response = delete_clients_ignore_dependencies_request(base_url, endpoint, client_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_client_with_alerts_ignore_dependencies():
@@ -66,7 +66,7 @@ def test_delete_client_with_alerts_ignore_dependencies():
     client_id = create_response.json()['id']
     add_alert_to_client(client_id)
     response = delete_clients_ignore_dependencies_request(base_url, endpoint, client_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_client_with_reviews_ignore_dependencies():
@@ -75,7 +75,7 @@ def test_delete_client_with_reviews_ignore_dependencies():
     client_id = create_response.json()['id']
     add_review_to_client(client_id)
     response = delete_clients_ignore_dependencies_request(base_url, endpoint, client_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_client_unauthorized():

--- a/src/be/tests/clients/test_get_clients_by_id.py
+++ b/src/be/tests/clients/test_get_clients_by_id.py
@@ -7,6 +7,7 @@ from src.be.utilities.error_schema import error_schema
 from src.be.utilities.clients_utilities.json_schemas.get_client_by_id_schema import get_clients_schema
 from src.be.utilities.useful_functions import get_random_uuid, random_string, standard_headers, \
     validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "clients/"
@@ -38,8 +39,9 @@ def test_get_client_by_id_null():
 
 def test_get_client_by_id_misspelled_endpoint():
     response = get_client_request(base_url, "client/", get_random_uuid(), headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_client_by_id_wrong_format():

--- a/src/be/tests/jobs/test_delete_job.py
+++ b/src/be/tests/jobs/test_delete_job.py
@@ -21,11 +21,9 @@ def test_delete_job_without_dependencies():
     assert post_response.status_code == 200
     job_id = post_response.json()['id']
     delete_response = delete_job_ignore_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_jobs_request(base_url, endpoint + job_id, "", headers)
-    assert get_response.status_code == 404
-    core_response = get_job_by_id_from_core_api(job_id)
-    assert core_response.status_code == 404
+    assert get_response.status_code == 200
 
 
 def test_delete_job_wrong_content_type():
@@ -34,7 +32,7 @@ def test_delete_job_wrong_content_type():
     assert post_response.status_code == 200
     job_id = post_response.json()['id']
     delete_response = delete_job_ignore_dependencies(base_url, endpoint, job_id, heads)
-    assert delete_response.status_code in [400, 415]
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_unauthorized():
@@ -42,14 +40,13 @@ def test_delete_job_unauthorized():
     assert post_response.status_code == 200
     job_id = post_response.json()['id']
     delete_response = delete_job_ignore_dependencies(base_url, endpoint, job_id, "")
-    assert delete_response.status_code in (401, 403), f"Expected 401 or 403, but got {delete_response.status_code}"
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_nonexistent_id():
     job_id = get_random_uuid()
     delete_response = delete_job_checking_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_already_deleted():
@@ -57,10 +54,7 @@ def test_delete_job_already_deleted():
     assert post_response.status_code == 200
     job_id = post_response.json()['id']
     delete_response = delete_job_checking_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 204
-    delete_response = delete_job_checking_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 404
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_with_activities_checking_dependencies():
@@ -69,8 +63,7 @@ def test_delete_job_with_activities_checking_dependencies():
     job_id = post_response.json()['id']
     add_activity_to_job(job_id)
     delete_response = delete_job_checking_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 400
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_with_alerts_checking_dependencies():
@@ -79,8 +72,7 @@ def test_delete_job_with_alerts_checking_dependencies():
     job_id = post_response.json()['id']
     add_alert_to_job(job_id)
     delete_response = delete_job_checking_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 400
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_with_candidates_checking_dependencies():
@@ -90,8 +82,7 @@ def test_delete_job_with_candidates_checking_dependencies():
     candidate_id = get_candidate_id()
     add_candidate_to_job(candidate_id, job_id)
     delete_response = delete_job_checking_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 400
-    validate(delete_response.json(), schema=error_schema)
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_with_candidates_ignore_dependencies():
@@ -101,7 +92,7 @@ def test_delete_job_with_candidates_ignore_dependencies():
     candidate_id = get_candidate_id()
     add_candidate_to_job(candidate_id, job_id)
     delete_response = delete_job_ignore_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_with_alerts_ignore_dependencies():
@@ -110,7 +101,7 @@ def test_delete_job_with_alerts_ignore_dependencies():
     job_id = post_response.json()['id']
     add_alert_to_job(job_id)
     delete_response = delete_job_ignore_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
 
 
 def test_delete_job_with_activities_ignore_dependencies():
@@ -119,4 +110,4 @@ def test_delete_job_with_activities_ignore_dependencies():
     job_id = post_response.json()['id']
     add_activity_to_job(job_id)
     delete_response = delete_job_ignore_dependencies(base_url, endpoint, job_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403

--- a/src/be/tests/jobs/test_get_jobs_by_id.py
+++ b/src/be/tests/jobs/test_get_jobs_by_id.py
@@ -4,6 +4,7 @@ from src.be.utilities.error_schema import error_schema
 from src.be.utilities.job_utilities.json_schemas.get_jobs_by_id_schema import get_jobs_schema
 from src.be.utilities.job_utilities.request_payloads.create_job_payload import create_job_full_payload
 from src.be.utilities.useful_functions import get_random_uuid, standard_headers, validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "jobs/"
@@ -30,8 +31,9 @@ def test_get_jobs_by_nonexistent_id():
 
 def test_get_jobs_by_id_misspelled_endpoint():
     response = get_jobs_request(base_url, "job/", get_random_uuid(), headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_jobs_by_id_wrong_format():

--- a/src/be/tests/organisations/test_delete_organisations.py
+++ b/src/be/tests/organisations/test_delete_organisations.py
@@ -19,11 +19,11 @@ def test_delete_organisations_without_dependencies():
     assert create_response.status_code == 200
     org_id = create_response.json()['id']
     delete_response = delete_organisations_request(base_url, endpoint, org_id, delete_headers)
-    assert delete_response.status_code == 204
+    assert delete_response.status_code == 403
     get_response = get_organisations_request(base_url, endpoint, org_id, headers)
-    assert get_response.status_code == 404
+    assert get_response.status_code == 200
     core_api_response = get_organisations_by_id_from_core_api(org_id)
-    assert core_api_response.status_code == 404, f"Response: {core_api_response.json()}"
+    assert core_api_response.status_code == 200, f"Response: {core_api_response.json()}"
 
 
 def test_delete_organisations_unauthorized():
@@ -36,7 +36,7 @@ def test_delete_organisations_unauthorized():
 
 def test_delete_organisations_nonexistent_id():
     delete_response = delete_organisations_request(base_url, endpoint, get_random_uuid(), delete_headers)
-    assert delete_response.status_code == 404
+    assert delete_response.status_code == 403
 
 
 def test_delete_organisations_wrong_endpoint():
@@ -45,7 +45,7 @@ def test_delete_organisations_wrong_endpoint():
     assert create_response.status_code == 200
     org_id = create_response.json()['id']
     delete_response = delete_organisations_request(base_url, "organisation", org_id, delete_headers)
-    assert delete_response.status_code == 404
+    assert delete_response.status_code == 403
 
 
 def test_delete_organisations_with_activities_checking_dependencies():
@@ -54,7 +54,7 @@ def test_delete_organisations_with_activities_checking_dependencies():
     org_id = create_response.json()['id']
     add_activity_to_organisation(org_id)
     response = delete_organisations_check_dependencies_request(base_url, endpoint, org_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_organisations_with_alerts_checking_dependencies():
@@ -63,7 +63,7 @@ def test_delete_organisations_with_alerts_checking_dependencies():
     org_id = create_response.json()['id']
     add_alert_to_organisation(org_id)
     response = delete_organisations_check_dependencies_request(base_url, endpoint, org_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 #
@@ -74,7 +74,7 @@ def test_delete_organisations_with_locations_checking_dependencies():
     org_id = create_response.json()['id']
     add_location_to_organisation(org_id)
     response = delete_organisations_check_dependencies_request(base_url, endpoint, org_id, delete_headers)
-    assert response.status_code == 400
+    assert response.status_code == 403
 
 
 def test_delete_organisations_with_activities_ignore_dependencies():
@@ -83,7 +83,7 @@ def test_delete_organisations_with_activities_ignore_dependencies():
     org_id = create_response.json()['id']
     add_activity_to_organisation(org_id)
     response = delete_organisations_ignore_dependencies_request(base_url, endpoint, org_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 def test_delete_organisations_with_alerts_ignore_dependencies():
@@ -92,7 +92,7 @@ def test_delete_organisations_with_alerts_ignore_dependencies():
     org_id = create_response.json()['id']
     add_alert_to_organisation(org_id)
     response = delete_organisations_ignore_dependencies_request(base_url, endpoint, org_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403
 
 
 #
@@ -103,4 +103,4 @@ def test_delete_organisations_with_locations_ignore_dependencies():
     org_id = create_response.json()['id']
     add_location_to_organisation(org_id)
     response = delete_organisations_ignore_dependencies_request(base_url, endpoint, org_id, delete_headers)
-    assert response.status_code == 204
+    assert response.status_code == 403

--- a/src/be/tests/organisations/test_get_organisations_by_id.py
+++ b/src/be/tests/organisations/test_get_organisations_by_id.py
@@ -5,6 +5,7 @@ from src.be.definitions.organisations_definitions import get_organisations_reque
 from src.be.utilities.error_schema import error_schema
 from src.be.utilities.organisations_utilities.json_schemas.get_organisations_schema import get_organisations_schema
 from src.be.utilities.useful_functions import get_random_uuid, standard_headers, validate_response_schema_and_fields
+from src.be.configuration.config_parser import assert_by_auth_type
 
 base_url = get_config_value("base_url")
 endpoint = "organisations/"
@@ -31,8 +32,9 @@ def test_get_organisations_by_nonexistent_id():
 
 def test_get_organisations_by_id_misspelled_endpoint():
     response = get_organisations_request(base_url, "organisation/", get_random_uuid(), headers)
-    assert response.status_code == 404
-    validate_response_schema_and_fields(response.json(), error_schema)
+    xapi_setting = get_config_value("xapi")
+    config = {"xapi": xapi_setting}
+    assert_by_auth_type(response, config)
 
 
 def test_get_organisations_by_id_wrong_format():


### PR DESCRIPTION
Modified the DELETE method tests to assert a 403 Forbidden response. The test flow was adjusted to skip further validations once the 403 is received. This is a temporary solution, implemented while we await clarification on whether full test coverage is needed for DELETE endpoints or if a simple 403 assertion will be sufficient going forward.

Updated the assertions for certain test scenarios where the x-api authentication method returns different status codes depending on the configuration. Specifically, when xapi = on, the request returns a 403 due to Istio and JWT handling; when xapi = off, it returns a 404. The test assertions now dynamically validate the expected response code based on the current xapi configuration.

Updated the authentication method from JWT to x-api-key, which is the default method used by Integrations.

